### PR TITLE
Return translation server testing with a v2 test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ zotero-build
 zotero-connectors
 zotero-standalone-build
 zotero-translators
+translation-server

--- a/config.sh
+++ b/config.sh
@@ -11,18 +11,19 @@ CONNECTORS_DIR="$SCRIPT_DIR/zotero-connectors"
 TRANSLATORS_REPO="git://github.com/zotero/translators.git"
 TRANSLATORS_DIR="$SCRIPT_DIR/translators"
 
+TRANSLATION_SERVER_REPO="git@github.com:zotero/translation-server.git"
 TRANSLATION_SERVER_DIR="$SCRIPT_DIR/translation-server"
 
 TEMP_PROFILE_DIR="$SCRIPT_DIR/tmp_profile"
 OUTPUT_DIR="${OUTPUT_DIR:-$SCRIPT_DIR/output/`date -u +%Y-%m-%d`}"
 
-TEST_GECKO=1
+TEST_GECKO=0
 TEST_BOOKMARKLET_IE=0
 TEST_BOOKMARKLET_CHROME=0
 TEST_BOOKMARKLET_GECKO=0
 TEST_CHROME=0
 TEST_SAFARI=0
-TEST_SERVER=0
+TEST_SERVER=1
 
 # Safari extension directory
 # Safari homepage must be set to http://127.0.0.1:23119/provo/run for testing

--- a/test_v2.sh
+++ b/test_v2.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+. "$SCRIPT_DIR/config.sh"
+TRANSLATORS_DIR="$SCRIPT_DIR/zotero-translators"
+
+if [ "`uname`" = "Darwin" ]; then
+	MAC_NATIVE=1
+else
+	MAC_NATIVE=0
+fi
+if [ "`uname -o 2> /dev/null`" = "Cygwin" ]; then
+	WIN_NATIVE=1
+else
+	WIN_NATIVE=0
+fi
+
+# Run tests
+function runTests {
+	# Test server
+	if [ $TEST_SERVER == 1 ]; then
+		if [ ! -d "$TRANSLATION_SERVER_DIR" ]; then
+			echo "$TRANSLATION_SERVER_DIR does not exist; not testing translation-server"
+		else
+			echo "Running translation-server tests"
+			suffix="translation-server.SOURCE.`git log -n 1 --pretty='format:%h'`"
+			outputFile="$OUTPUT_DIR/testResults-v-$suffix.json"
+			
+			cd "$TRANSLATION_SERVER_DIR"
+			nodejs ./test/testTranslators/testTranslators.js -o "$outputFile" -g "PubMed" > /dev/null
+		fi
+	fi
+}
+
+# Make sure translators directory exists and is up-to-date
+echo "Updating translators"
+if [ ! -d "$TRANSLATORS_DIR" ]; then
+	git clone "$TRANSLATORS_REPO" "$TRANSLATORS_DIR"
+else
+	cd "$TRANSLATORS_DIR"
+	git pull origin master
+fi
+echo
+
+# Create translation-server directory if it doesn't exist, or else update it
+echo "Updating translation-server"
+if [ ! -d "$TRANSLATION_SERVER_DIR" ]; then
+	git clone "$TRANSLATION_SERVER_REPO" "$TRANSLATION_SERVER_DIR"
+	cd "$TRANSLATION_SERVER_DIR"
+	git submodule update --init modules/zotero
+	# Link translators for the translation-server
+	rm -rf "modules/translators"
+	ln -s "$TRANSLATORS_DIR" "modules/translators"
+	npm i
+else
+	cd "$TRANSLATION_SERVER_DIR"
+	git pull origin master
+	git submodule update modules/zotero
+	npm i
+fi
+echo
+
+# Make output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Run prerun.sh if it exists
+if [ -e "$SCRIPT_DIR/prerun.sh" ]; then
+	. "$SCRIPT_DIR/prerun.sh"
+fi
+
+# Test
+runTests
+
+# Run postrun.sh if it exists
+if [ -e "$SCRIPT_DIR/postrun.sh" ]; then
+	. "$SCRIPT_DIR/postrun.sh"
+fi


### PR DESCRIPTION
I'd like to start setting up provo for the modern Zotero codebase.

This would involve putting some additional endpoints on the translation server to enable testing the connectors and the bookmarklet, which will come in the future, but for now, this adds `test_v2.sh`, which will test translation server generating the usual test-results file.